### PR TITLE
detect and use minitest/reporters when `--reporter` specified

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -171,6 +171,10 @@ module Zeus
             exit
           end
 
+          opts.on '--reporter REPORTER', 'Configure the reporter' do |reporter|
+            @reporter = reporter
+          end
+
           opts.on '-l', '--line LINE', Integer, 'Line number for file.' do |line|
             @line = line
           end
@@ -191,6 +195,18 @@ module Zeus
         generate_tests_to_run
 
         test_arguments = build_test_arguments
+
+        if @reporter
+          begin
+            require 'minitest/reporters'
+            klass_name = @reporter.capitalize + 'Reporter'
+            Minitest::Reporters.use! Minitest::Reporters.const_get(klass_name).new
+          rescue LoadError
+            puts "Requiring `minitest/reporters` failed. Continuing..."
+          rescue NameError
+            puts "Loading reporter #{@reporter} failed. Continuing..."
+          end
+        end
 
         # directly run the tests from here and exit with the status of the tests passing or failing
         case framework

--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -199,8 +199,7 @@ module Zeus
         if @reporter
           begin
             require 'minitest/reporters'
-            klass_name = @reporter.capitalize + 'Reporter'
-            Minitest::Reporters.use! Minitest::Reporters.const_get(klass_name).new
+            Minitest::Reporters.use! Minitest::Reporters.const_get(@reporter, false).new
           rescue LoadError
             puts "Requiring `minitest/reporters` failed. Continuing..."
           rescue NameError


### PR DESCRIPTION
this PR enables a project that uses `minitest/reporters` to configure the test output:

for example:

```
$ zeus test --reporter spec test/a_test.rb
Started with run options --seed 33193

when updating an order
  test_0005_automatically refunds when returning an order         PASS (7.47s)
  test_0003_return a 404 when the order does not exist            PASS (0.59s)
  ...
```
